### PR TITLE
Retry read failures for a maximum amount of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Join CDAP community](https://cdap-users.herokuapp.com/badge.svg?t=wrangler)](https://cdap-users.herokuapp.com?t=1)
 
-Change Data Capture
-===================
+Change Data Capture (Alpha)
+===========================
 
 In databases, Change Data Capture(CDC) is used to determine and track the data that has changed so that
 action can be taken using the changed data. This repository contains CDAP plugins which allows to capture

--- a/docs/CTSQLServer-streamingsource.md
+++ b/docs/CTSQLServer-streamingsource.md
@@ -25,6 +25,10 @@ Optional for databases that do not require authentication.
 **Database name**:  SQL Server database name which needs to be tracked. 
 Note: Change Tracking must be enabled on the database for the source to read the chage data.
 
+**Max Retry Seconds**: Maximum number of seconds to retry failures when reading change events.
+If no retries should be done, this should be set to 0.
+If there should not be a retry limit, this should be set to a negative number or left empty.
+
 SQL Server Change Tracking
 --------------------------
 Change Tracking allows to identify the rows which have changed. Change Tracking SQL Server Streaming Source leverage 

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServer.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServer.java
@@ -93,7 +93,8 @@ public class CTSQLServer extends StreamingSource<StructuredRecord> {
     // get change information dtream. This dstream has both schema and data changes
     LOG.info("Creating change information dstream");
     ClassTag<StructuredRecord> tag = ClassTag$.MODULE$.apply(StructuredRecord.class);
-    CTInputDStream dstream = new CTInputDStream(context.getSparkStreamingContext().ssc(), dbConnection);
+    CTInputDStream dstream = new CTInputDStream(context.getSparkStreamingContext().ssc(), dbConnection,
+                                                conf.getMaxRetrySeconds());
     return JavaDStream.fromDStream(dstream, tag)
       .mapToPair(structuredRecord -> new Tuple2<>("", structuredRecord))
       // map the dstream with schema state store to detect changes in schema

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServerConfig.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServerConfig.java
@@ -35,6 +35,7 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   public static final String USERNAME = "username";
   public static final String PASSWORD = "password";
   public static final String DATABASE_NAME = "dbname";
+  public static final String MAX_RETRY_SECONDS = "maxRetrySeconds";
 
   @Name(HOST_NAME)
   @Description("SQL Server hostname. Ex: mysqlsever.net")
@@ -65,11 +66,19 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   @Macro
   private final String password;
 
+  @Name(MAX_RETRY_SECONDS)
+  @Description("Maximum amount of time to retry reading change events if there is an error. "
+    + "If no retries should be done, this should be set to 0. "
+    + "If there should not be a retry limit, this should be set to a negative number or left empty.")
+  @Nullable
+  private final Long maxRetrySeconds;
+
   public CTSQLServerConfig() {
     super("");
     port = 1433;
     username = null;
     password = null;
+    maxRetrySeconds = -1L;
   }
 
   public CTSQLServerConfig(String referenceName, String hostname, int port, String dbName, String username,
@@ -80,6 +89,7 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
     this.dbName = dbName;
     this.username = username;
     this.password = password;
+    this.maxRetrySeconds = 0L;
   }
 
   public String getHostname() {
@@ -102,6 +112,10 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   @Nullable
   public String getPassword() {
     return password;
+  }
+
+  public long getMaxRetrySeconds() {
+    return maxRetrySeconds == null ? -1L : maxRetrySeconds;
   }
 
   @Override

--- a/widgets/CTSQLServer-streamingsource.json
+++ b/widgets/CTSQLServer-streamingsource.json
@@ -44,6 +44,11 @@
           "label": "Database name",
           "name": "dbname",
           "description": "SQL Server database name which needs to be tracked. Note: Change Tracking must be enabled on the database for the source to read the chage data"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Max Retry Seconds",
+          "name": "maxRetrySeconds"
         }
       ]
     }
@@ -52,12 +57,61 @@
     {
       "widget-type": "non-editable-schema-editor",
       "schema": {
-        "name": "CDCRecord",
+        "name": "changeRecord",
         "type": "record",
         "fields": [
           {
-            "name": "cdcMessage",
-            "type": "bytes"
+            "name": "ddl",
+            "type": [
+              {
+                "type": "record",
+                "name": "DDLRecord",
+                "fields": [
+                  { "name": "table", "type":  "string" },
+                  { "name":  "schema", "type":  "string" }
+                ]
+              },
+              "null"
+            ]
+          },
+          {
+            "name": "dml",
+            "type": [
+              {
+                "type": "record",
+                "name": "DMLRecord",
+                "fields": [
+                  {
+                    "name": "op_type",
+                    "type": {
+                      "symbols": [ "INSERT", "UPDATE", "DELETE" ],
+                      "type": "enum"
+                    }
+                  },
+                  { "name": "table", "type": "string" },
+                  { "name": "primary_keys", "type": { "type": "array", "items": "string" } },
+                  { "name": "rows_schema", "type": "string" },
+                  {
+                    "name": "rows_values",
+                    "type": {
+                      "type": "map",
+                      "keys": "string",
+                      "values": [
+                        "null",
+                        "boolean",
+                        "int",
+                        "long",
+                        "float",
+                        "double",
+                        "bytes",
+                        "string"
+                      ]
+                    }
+                  }
+                ]
+              },
+              "null"
+            ]
           }
         ]
       }


### PR DESCRIPTION
Instead of failing the pipeline the moment a read exception occurs,
return an empty RDD to ensure the pipeline keeps running in cases
of temporary problems.