### PR TITLE
enhancements to sqlserver source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -516,11 +516,6 @@
     </dependency>
     <!-- Dependency for sql server ct-->
     <dependency>
-      <groupId>io.cdap.plugin</groupId>
-      <artifactId>database-plugins</artifactId>
-      <version>${hydrator.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
       <version>${mssql.jdbc.version}</version>

--- a/src/main/java/io/cdap/plugin/cdc/DMLFlattener.java
+++ b/src/main/java/io/cdap/plugin/cdc/DMLFlattener.java
@@ -100,7 +100,10 @@ public class DMLFlattener extends Transform<StructuredRecord, StructuredRecord> 
   }
 
   private Schema createOutputSchema(Schema rowSchema) {
-    List<Schema.Field> fields = new ArrayList<>(rowSchema.getFields().size() + 2);
+    // the transform optionally adds a OP_TYPE field and CHANGE_TRACKING_VERSION field that do not come from the
+    // actual row data, but from general change tracking information.
+    int numFields = rowSchema.getFields().size() + (addOpType ? 1 : 0) + (addTrackingVersion ? 1 : 0);
+    List<Schema.Field> fields = new ArrayList<>(numFields);
     fields.addAll(rowSchema.getFields());
     if (addOpType) {
       fields.add(Schema.Field.of(OP_TYPE, Schema.of(Schema.Type.STRING)));

--- a/src/main/java/io/cdap/plugin/cdc/DMLFlattener.java
+++ b/src/main/java/io/cdap/plugin/cdc/DMLFlattener.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.cdc;
+
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.Transform;
+import io.cdap.cdap.etl.api.TransformContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Extracts the DML record from the output of a cdc source for direct manipulation.
+ */
+@Plugin(type = Transform.PLUGIN_TYPE)
+@Name("DMLFlattener")
+@Description("Flattens DML records output by a CDC source.")
+public class DMLFlattener extends Transform<StructuredRecord, StructuredRecord> {
+  private static final String OP_TYPE = "CDC_OP_TYPE";
+  private static final String CHANGE_TRACKING_VERSION = "CHANGE_TRACKING_VERSION";
+  private final Conf conf;
+  private Map<Schema, Schema> schemaCache;
+  private Schema configuredOutputSchema;
+  private boolean addOpType = false;
+  private boolean addTrackingVersion = false;
+
+  public DMLFlattener(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    if (conf.schema != null) {
+      try {
+        pipelineConfigurer.getStageConfigurer().setOutputSchema(Schema.parseJson(conf.schema));
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Unable to parse configured schema: " + e.getMessage(), e);
+      }
+    }
+  }
+
+  @Override
+  public void initialize(TransformContext context) throws IOException {
+    configuredOutputSchema = conf.schema == null ? null : Schema.parseJson(conf.schema);
+    addOpType = configuredOutputSchema.getField(OP_TYPE) != null;
+    addTrackingVersion = configuredOutputSchema.getField(CHANGE_TRACKING_VERSION) != null;
+    schemaCache = new HashMap<>();
+  }
+
+  @Override
+  public void transform(StructuredRecord record, Emitter<StructuredRecord> emitter) throws Exception {
+    StructuredRecord dml = record.get("dml");
+    if (dml == null) {
+      return;
+    }
+
+    Schema rowSchema = Schema.parseJson((String) dml.get("rows_schema"));
+    Schema outputSchema = schemaCache.computeIfAbsent(rowSchema, this::createOutputSchema);
+
+    StructuredRecord.Builder output = StructuredRecord.builder(outputSchema);
+    if (addOpType) {
+      output.set(OP_TYPE, dml.get("op_type").toString());
+    }
+    if (addTrackingVersion) {
+      output.set(CHANGE_TRACKING_VERSION, dml.get("change_tracking_version"));
+    }
+    Map<String, Object> valueMap = dml.get("rows_values");
+    if (valueMap == null) {
+      valueMap = new HashMap<>();
+    }
+    for (Map.Entry<String, Object> entry : valueMap.entrySet()) {
+      output.set(entry.getKey(), entry.getValue());
+    }
+    emitter.emit(output.build());
+  }
+
+  private Schema createOutputSchema(Schema rowSchema) {
+    List<Schema.Field> fields = new ArrayList<>(rowSchema.getFields().size() + 2);
+    fields.addAll(rowSchema.getFields());
+    if (addOpType) {
+      fields.add(Schema.Field.of(OP_TYPE, Schema.of(Schema.Type.STRING)));
+    }
+    if (addTrackingVersion) {
+      fields.add(Schema.Field.of(CHANGE_TRACKING_VERSION, Schema.of(Schema.Type.STRING)));
+    }
+    return Schema.recordOf(rowSchema + ".added", fields);
+  }
+
+  /**
+   * plugin config.
+   */
+  public static class Conf extends PluginConfig {
+
+    @Nullable
+    @Description("The output schema of DML records. This should only be set if the source has been configured to read "
+      + "from a single table whose schema will never change.")
+    private String schema;
+  }
+}

--- a/src/main/java/io/cdap/plugin/cdc/common/Schemas.java
+++ b/src/main/java/io/cdap/plugin/cdc/common/Schemas.java
@@ -44,6 +44,7 @@ public class Schemas {
   public static final String DML_FIELD = "dml";
   public static final String UPDATE_SCHEMA_FIELD = "rows_schema";
   public static final String UPDATE_VALUES_FIELD = "rows_values";
+  public static final String CHANGE_TRACKING_VERSION = "change_tracking_version";
 
   public static final Schema DDL_SCHEMA = Schema.recordOf(
     "DDLRecord",
@@ -57,7 +58,8 @@ public class Schemas {
     Field.of(TABLE_FIELD, Schema.of(Type.STRING)),
     Field.of(PRIMARY_KEYS_FIELD, Schema.arrayOf(Schema.of(Type.STRING))),
     Field.of(UPDATE_SCHEMA_FIELD, Schema.of(Type.STRING)),
-    Field.of(UPDATE_VALUES_FIELD, Schema.mapOf(Schema.of(Type.STRING), SIMPLE_TYPES))
+    Field.of(UPDATE_VALUES_FIELD, Schema.mapOf(Schema.of(Type.STRING), SIMPLE_TYPES)),
+    Field.of(CHANGE_TRACKING_VERSION, Schema.of(Type.STRING))
   );
 
   public static final Schema CHANGE_SCHEMA = Schema.recordOf(

--- a/src/main/java/io/cdap/plugin/cdc/source/DBUtils.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/DBUtils.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.cdc.source;
+
+import com.google.common.collect.Lists;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
+
+import java.math.BigDecimal;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Utility methods for Database plugins shared by Database plugins.
+ */
+public final class DBUtils {
+
+
+  /**
+   * Given the result set, get the metadata of the result set and return
+   * list of {@link io.cdap.cdap.api.data.schema.Schema.Field}.
+   *
+   * @param resultSet result set of executed query
+   * @return list of schema fields
+   * @throws SQLException
+   */
+  public static List<Schema.Field> getSchemaFields(ResultSet resultSet) throws SQLException {
+    List<Schema.Field> schemaFields = Lists.newArrayList();
+    ResultSetMetaData metadata = resultSet.getMetaData();
+    // ResultSetMetadata columns are numbered starting with 1
+    for (int i = 1; i <= metadata.getColumnCount(); i++) {
+      String columnName = metadata.getColumnName(i);
+      int columnSqlType = metadata.getColumnType(i);
+      int columnSqlPrecision = metadata.getPrecision(i); // total number of digits
+      int columnSqlScale = metadata.getScale(i); // digits after the decimal point
+      String columnTypeName = metadata.getColumnTypeName(i);
+      Schema columnSchema = getSchema(columnTypeName, columnSqlType, columnSqlPrecision, columnSqlScale);
+      if (ResultSetMetaData.columnNullable == metadata.isNullable(i)) {
+        columnSchema = Schema.nullableOf(columnSchema);
+      }
+      Schema.Field field = Schema.Field.of(columnName, columnSchema);
+      schemaFields.add(field);
+    }
+    return schemaFields;
+  }
+
+  // given a sql type return schema type
+  private static Schema getSchema(String typeName, int sqlType, int precision, int scale) throws SQLException {
+    // Type.STRING covers sql types - VARCHAR,CHAR,CLOB,LONGNVARCHAR,LONGVARCHAR,NCHAR,NCLOB,NVARCHAR
+    Schema.Type type = Schema.Type.STRING;
+    switch (sqlType) {
+      case Types.NULL:
+        type = Schema.Type.NULL;
+        break;
+
+      case Types.ROWID:
+        break;
+
+      case Types.BOOLEAN:
+      case Types.BIT:
+        type = Schema.Type.BOOLEAN;
+        break;
+
+      case Types.TINYINT:
+      case Types.SMALLINT:
+        type = Schema.Type.INT;
+        break;
+      case Types.INTEGER:
+        // CDAP-12211 - handling unsigned integers in mysql
+        type = "int unsigned".equalsIgnoreCase(typeName) ? Schema.Type.LONG : Schema.Type.INT;
+        break;
+
+      case Types.BIGINT:
+        type = Schema.Type.LONG;
+        break;
+
+      case Types.REAL:
+      case Types.FLOAT:
+        type = Schema.Type.FLOAT;
+        break;
+
+      case Types.NUMERIC:
+      case Types.DECIMAL:
+        // if there are no digits after the point, use integer types
+        type = scale != 0 ? Schema.Type.DOUBLE :
+          // with 10 digits we can represent 2^32 and LONG is required
+          precision > 9 ? Schema.Type.LONG : Schema.Type.INT;
+        break;
+
+      case Types.DOUBLE:
+        type = Schema.Type.DOUBLE;
+        break;
+
+      case Types.DATE:
+        return Schema.of(Schema.LogicalType.DATE);
+      case Types.TIME:
+        return Schema.of(Schema.LogicalType.TIME_MICROS);
+      case Types.TIMESTAMP:
+        return Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
+
+      case Types.BINARY:
+      case Types.VARBINARY:
+      case Types.LONGVARBINARY:
+      case Types.BLOB:
+        type = Schema.Type.BYTES;
+        break;
+
+      case Types.ARRAY:
+      case Types.DATALINK:
+      case Types.DISTINCT:
+      case Types.JAVA_OBJECT:
+      case Types.OTHER:
+      case Types.REF:
+      case Types.SQLXML:
+      case Types.STRUCT:
+        throw new SQLException(new UnsupportedTypeException("Unsupported SQL Type: " + sqlType));
+    }
+
+    return Schema.of(type);
+  }
+
+  @Nullable
+  public static Object transformValue(int sqlType, int precision, int scale,
+                                      ResultSet resultSet, String fieldName) throws SQLException {
+    Object original = resultSet.getObject(fieldName);
+    if (original != null) {
+      switch (sqlType) {
+        case Types.SMALLINT:
+        case Types.TINYINT:
+          return ((Number) original).intValue();
+        case Types.NUMERIC:
+        case Types.DECIMAL:
+          BigDecimal decimal = (BigDecimal) original;
+          if (scale != 0) {
+            // if there are digits after the point, use double types
+            return decimal.doubleValue();
+          } else if (precision > 9) {
+            // with 10 digits we can represent 2^32 and LONG is required
+            return decimal.longValue();
+          } else {
+            return decimal.intValue();
+          }
+        case Types.DATE:
+          return resultSet.getDate(fieldName);
+        case Types.TIME:
+          return resultSet.getTime(fieldName);
+        case Types.TIMESTAMP:
+          return resultSet.getTimestamp(fieldName);
+        case Types.ROWID:
+          return resultSet.getString(fieldName);
+        case Types.BLOB:
+          Blob blob = (Blob) original;
+          return blob.getBytes(1, (int) blob.length());
+        case Types.CLOB:
+          Clob clob = (Clob) original;
+          return clob.getSubString(1, (int) clob.length());
+      }
+    }
+    return original;
+  }
+
+  private DBUtils() {
+    throw new AssertionError("Should not instantiate static utility class.");
+  }
+}
+

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServer.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServer.java
@@ -94,7 +94,8 @@ public class CTSQLServer extends StreamingSource<StructuredRecord> {
     LOG.info("Creating change information dstream");
     ClassTag<StructuredRecord> tag = ClassTag$.MODULE$.apply(StructuredRecord.class);
     CTInputDStream dstream = new CTInputDStream(context.getSparkStreamingContext().ssc(), dbConnection,
-                                                conf.getMaxRetrySeconds());
+                                                conf.getTableWhitelist(), conf.getSequenceStartNum(),
+                                                conf.getMaxRetrySeconds(), conf.getMaxBatchSize());
     return JavaDStream.fromDStream(dstream, tag)
       .mapToPair(structuredRecord -> new Tuple2<>("", structuredRecord))
       // map the dstream with schema state store to detect changes in schema

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServerConfig.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServerConfig.java
@@ -23,6 +23,10 @@ import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.etl.api.validation.InvalidConfigPropertyException;
 import io.cdap.plugin.cdc.common.CDCReferencePluginConfig;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -35,7 +39,10 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   public static final String USERNAME = "username";
   public static final String PASSWORD = "password";
   public static final String DATABASE_NAME = "dbname";
+  public static final String SEQUENCE_START_NUM = "sequenceStartNum";
   public static final String MAX_RETRY_SECONDS = "maxRetrySeconds";
+  public static final String MAX_BATCH_SIZE = "maxBatchSize";
+  public static final String TABLE_WHITELIST = "tableWhitelist";
 
   @Name(HOST_NAME)
   @Description("SQL Server hostname. Ex: mysqlsever.net")
@@ -73,23 +80,33 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   @Nullable
   private final Long maxRetrySeconds;
 
+  @Name(SEQUENCE_START_NUM)
+  @Description("The Change Tracking sequence number to start from.")
+  @Nullable
+  private final Long sequenceStartNum;
+
+  @Name(MAX_BATCH_SIZE)
+  @Description("Maximum number of changes to consume in a single batch interval.")
+  @Nullable
+  private final Integer maxBatchSize;
+
+  @Name(TABLE_WHITELIST)
+  @Description("A whitelist of tables to consume changes from. "
+    + "If none is specified, changes from all tables will be consumed.")
+  @Nullable
+  private final String tableWhitelist;
+
   public CTSQLServerConfig() {
     super("");
-    port = 1433;
-    username = null;
-    password = null;
-    maxRetrySeconds = -1L;
-  }
-
-  public CTSQLServerConfig(String referenceName, String hostname, int port, String dbName, String username,
-                           String password) {
-    super(referenceName);
-    this.hostname = hostname;
-    this.port = port;
-    this.dbName = dbName;
-    this.username = username;
-    this.password = password;
-    this.maxRetrySeconds = 0L;
+    this.hostname = null;
+    this.port = 1433;
+    this.dbName = null;
+    this.username = null;
+    this.password = null;
+    this.sequenceStartNum = 0L;
+    this.maxRetrySeconds = -1L;
+    this.maxBatchSize = 100000;
+    this.tableWhitelist = null;
   }
 
   public String getHostname() {
@@ -114,8 +131,21 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
     return password;
   }
 
+  public long getSequenceStartNum() {
+    return sequenceStartNum == null ? 0L : sequenceStartNum;
+  }
+
   public long getMaxRetrySeconds() {
     return maxRetrySeconds == null ? -1L : maxRetrySeconds;
+  }
+
+  public int getMaxBatchSize() {
+    return maxBatchSize == null ? 100000 : maxBatchSize;
+  }
+
+  public Set<String> getTableWhitelist() {
+    return tableWhitelist == null ? Collections.emptySet() :
+      Arrays.stream(tableWhitelist.split(",")).map(String::trim).collect(Collectors.toSet());
   }
 
   @Override

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/ResultSetToDDLRecord.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/ResultSetToDDLRecord.java
@@ -19,8 +19,8 @@ package io.cdap.plugin.cdc.source.sqlserver;
 import com.google.common.base.Joiner;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.plugin.DBUtils;
 import io.cdap.plugin.cdc.common.Schemas;
+import io.cdap.plugin.cdc.source.DBUtils;
 import org.apache.spark.api.java.function.Function;
 
 import java.sql.ResultSet;

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/ResultSetToDMLRecord.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/ResultSetToDMLRecord.java
@@ -20,10 +20,12 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.plugin.DBUtils;
 import io.cdap.plugin.cdc.common.OperationType;
 import io.cdap.plugin.cdc.common.Schemas;
+import io.cdap.plugin.cdc.source.DBUtils;
 import org.apache.spark.api.java.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Date;
 import java.sql.ResultSet;
@@ -40,7 +42,8 @@ import java.util.Map;
  * to {@link StructuredRecord} for dml records
  */
 public class ResultSetToDMLRecord implements Function<ResultSet, StructuredRecord> {
-  private static final int CHANGE_TABLE_COLUMNS_SIZE = 3;
+  private static final Logger LOG = LoggerFactory.getLogger(ResultSetToDMLRecord.class);
+  private static final int CHANGE_TABLE_COLUMNS_SIZE = 4;
   private final TableInformation tableInformation;
 
   ResultSetToDMLRecord(TableInformation tableInformation) {
@@ -58,6 +61,7 @@ public class ResultSetToDMLRecord implements Function<ResultSet, StructuredRecor
       .set(Schemas.OP_TYPE_FIELD, operationType.name())
       .set(Schemas.UPDATE_SCHEMA_FIELD, changeSchema.toString())
       .set(Schemas.UPDATE_VALUES_FIELD, getChangeData(row, changeSchema))
+      .set(Schemas.CHANGE_TRACKING_VERSION, row.getString("CHANGE_TRACKING_VERSION"))
       .build();
   }
 
@@ -65,7 +69,7 @@ public class ResultSetToDMLRecord implements Function<ResultSet, StructuredRecor
     ResultSetMetaData metadata = resultSet.getMetaData();
     Map<String, Object> changes = new HashMap<>();
     for (int i = 0; i < changeSchema.getFields().size(); i++) {
-      int column = i + CHANGE_TABLE_COLUMNS_SIZE;
+      int column = 1 + i + CHANGE_TABLE_COLUMNS_SIZE;
       int sqlType = metadata.getColumnType(column);
       int sqlPrecision = metadata.getPrecision(column);
       int sqlScale = metadata.getScale(column);

--- a/widgets/CTSQLServer-streamingsource.json
+++ b/widgets/CTSQLServer-streamingsource.json
@@ -49,6 +49,27 @@
           "widget-type": "textbox",
           "label": "Max Retry Seconds",
           "name": "maxRetrySeconds"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Max Batch Size",
+          "name": "maxBatchSize",
+          "widget-attributes": {
+            "default": "100000"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Starting Sequence Number",
+          "name": "sequenceStartNum",
+          "widget-attributes": {
+            "default": "0"
+          }
+        },
+        {
+          "widget-type": "csv",
+          "label": "Table Whitelist",
+          "name": "tableWhitelist"
         }
       ]
     }
@@ -107,7 +128,8 @@
                         "string"
                       ]
                     }
-                  }
+                  },
+                  { "name": "change_tracking_version", "type": "string" }
                 ]
               },
               "null"

--- a/widgets/DMLFlattener-transform.json
+++ b/widgets/DMLFlattener-transform.json
@@ -1,0 +1,22 @@
+{
+  "metadata": {
+    "spec-version": "1.5"
+  },
+  "display-name": "DML Flattener",
+  "configuration-groups": [
+    {
+      "label": "Basic",
+      "properties": [ ]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "schema",
+      "widget-type": "schema",
+      "widget-attributes": {
+        "schema-default-type": "string"
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
Added the following enhancements:

 - The CDC sequence number for the DML event is included in output

 - Added a starting sequence number to source properties to allow
   reading from a specific point

 - Don't lock when getting CDC events

 - Added ability to limit the number of changes to get in a batch
   to better handle situations where there are more changes than can
   be processed in a single batch interval

 - Added a property for a table whitelist to allow specifying
   a subset of table to consume changes for

 - Removed dependency on bulky db-plugins plugins, which were never
   meant to be used as a library. Instead, copied relevant utility methods
   into DBUtils class.

 - Added a transform for extracting the DML event as a top level
   record for direct manipulation.