### PR TITLE
add jdbc plugin support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>io.cdap.plugin</groupId>
   <artifactId>cdc-plugins</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>cdc-plugins</name>
 
   <licenses>
@@ -72,8 +72,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
-    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
+    <cdap.version>6.0.0</cdap.version>
+    <hydrator.version>2.2.0</hydrator.version>
     <google.cloud.core.version>1.61.0</google.cloud.core.version>
     <bigtable.version>1.8.0</bigtable.version>
     <spark.version>2.1.3</spark.version>
@@ -541,10 +541,6 @@
       <exclusions>
         <exclusion>
           <groupId>io.cdap.cdap</groupId>
-          <artifactId>cdap-api-spark</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.cdap.cdap</groupId>
           <artifactId>cdap-spark-core</artifactId>
         </exclusion>
       </exclusions>
@@ -553,7 +549,7 @@
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-api-spark2_2.11</artifactId>
       <version>${cdap.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>

--- a/src/main/java/io/cdap/plugin/cdc/common/DriverCleanup.java
+++ b/src/main/java/io/cdap/plugin/cdc/common/DriverCleanup.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.plugin.cdc.common;
+
+import com.google.common.base.Throwables;
+import io.cdap.cdap.etl.api.Destroyable;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import javax.annotation.Nullable;
+
+/**
+ * class to de-register driver
+ */
+public class DriverCleanup implements Destroyable {
+  private final JDBCDriverShim driverShim;
+
+  DriverCleanup(@Nullable JDBCDriverShim driverShim) {
+    this.driverShim = driverShim;
+  }
+
+  public void destroy() {
+    if (driverShim != null) {
+      try {
+        DriverManager.deregisterDriver(driverShim);
+      } catch (SQLException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+}
+

--- a/src/main/java/io/cdap/plugin/cdc/common/JDBCDriverShim.java
+++ b/src/main/java/io/cdap/plugin/cdc/common/JDBCDriverShim.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.plugin.cdc.common;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+/**
+ * Shim for JDBC driver as a better alternative to mere Class.forName to load the JDBC Driver class.
+ *
+ * From http://www.kfu.com/~nsayer/Java/dyn-jdbc.html
+ * One problem with using <pre>{@code Class.forName()}</pre> to find and load the JDBC Driver class is that it
+ * presumes that your driver is in the classpath. This means either packaging the driver in your jar, or having to
+ * stick the driver somewhere (probably unpacking it too), or modifying your classpath.
+ * But why not use something like URLClassLoader and the overload of Class.forName() that lets you specify the
+ * ClassLoader?" Because the DriverManager will refuse to use a driver not loaded by the system ClassLoader.
+ * The workaround for this is to create a shim class that implements java.sql.Driver.
+ * This shim class will do nothing but call the methods of an instance of a JDBC driver that we loaded dynamically.
+ */
+public class JDBCDriverShim implements Driver {
+
+  private final Driver delegate;
+
+  public JDBCDriverShim(Driver delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean acceptsURL(String url) throws SQLException {
+    return delegate.acceptsURL(url);
+  }
+
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
+    return delegate.connect(url, info);
+  }
+
+  @Override
+  public int getMajorVersion() {
+    return delegate.getMajorVersion();
+  }
+
+  @Override
+  public int getMinorVersion() {
+    return delegate.getMinorVersion();
+  }
+
+  @Override
+  public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
+    return delegate.getPropertyInfo(url, info);
+  }
+
+  @Override
+  public boolean jdbcCompliant() {
+    return delegate.jdbcCompliant();
+  }
+
+  @Override
+  public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    return delegate.getParentLogger();
+  }
+}

--- a/src/main/java/io/cdap/plugin/cdc/common/Schemas.java
+++ b/src/main/java/io/cdap/plugin/cdc/common/Schemas.java
@@ -45,6 +45,7 @@ public class Schemas {
   public static final String UPDATE_SCHEMA_FIELD = "rows_schema";
   public static final String UPDATE_VALUES_FIELD = "rows_values";
   public static final String CHANGE_TRACKING_VERSION = "change_tracking_version";
+  public static final String CDC_CURRENT_TIMESTAMP = "cdc_current_timestamp";
 
   public static final Schema DDL_SCHEMA = Schema.recordOf(
     "DDLRecord",
@@ -59,7 +60,8 @@ public class Schemas {
     Field.of(PRIMARY_KEYS_FIELD, Schema.arrayOf(Schema.of(Type.STRING))),
     Field.of(UPDATE_SCHEMA_FIELD, Schema.of(Type.STRING)),
     Field.of(UPDATE_VALUES_FIELD, Schema.mapOf(Schema.of(Type.STRING), SIMPLE_TYPES)),
-    Field.of(CHANGE_TRACKING_VERSION, Schema.of(Type.STRING))
+    Field.of(CHANGE_TRACKING_VERSION, Schema.of(Type.STRING)),
+    Field.of(CDC_CURRENT_TIMESTAMP, Schema.of(Schema.LogicalType.TIME_MICROS))
   );
 
   public static final Schema CHANGE_SCHEMA = Schema.recordOf(

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/PluginConnectionFactory.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/PluginConnectionFactory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.plugin.cdc.source.sqlserver;
+
+import io.cdap.cdap.api.plugin.PluginContext;
+import io.cdap.plugin.cdc.common.DBUtils;
+import org.apache.spark.rdd.JdbcRDD;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.Map;
+
+/**
+ * Serializable jdbc connection factory that uses CDAP plugin context to instantiate the jdbc driver.
+ */
+public class PluginConnectionFactory implements JdbcRDD.ConnectionFactory, Serializable {
+  private static final long serialVersionUID = -7897960584858589314L;
+  private final String stageName;
+  private final String connectionString;
+  private final PluginContext pluginContext;
+  private transient String user;
+  private transient String password;
+  private transient boolean initialized;
+
+  PluginConnectionFactory(PluginContext pluginContext, String stageName, String connectionString) {
+    this.stageName = stageName;
+    this.connectionString = connectionString;
+    this.pluginContext = pluginContext;
+  }
+
+  @Override
+  public Connection getConnection() throws Exception {
+    if (!initialized) {
+      Class<? extends Driver> driverClass = pluginContext.loadPluginClass(stageName + ":" + CTSQLServer.JDBC_PLUGIN_ID);
+      DBUtils.ensureJDBCDriverIsAvailable(driverClass, connectionString);
+      Map<String, String> stageProperties = pluginContext.getPluginProperties(stageName).getProperties();
+      user = stageProperties.get(CTSQLServerConfig.USERNAME);
+      password = stageProperties.get(CTSQLServerConfig.PASSWORD);
+      initialized = true;
+    }
+    return DriverManager.getConnection(connectionString, user, password);
+  }
+
+  private void initialize() {
+
+  }
+}

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/ResultSetToDDLRecord.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/ResultSetToDDLRecord.java
@@ -19,8 +19,8 @@ package io.cdap.plugin.cdc.source.sqlserver;
 import com.google.common.base.Joiner;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.cdc.common.DBUtils;
 import io.cdap.plugin.cdc.common.Schemas;
-import io.cdap.plugin.cdc.source.DBUtils;
 import org.apache.spark.api.java.function.Function;
 
 import java.sql.ResultSet;

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/ResultSetToDMLRecord.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/ResultSetToDMLRecord.java
@@ -20,9 +20,9 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.plugin.cdc.common.DBUtils;
 import io.cdap.plugin.cdc.common.OperationType;
 import io.cdap.plugin.cdc.common.Schemas;
-import io.cdap.plugin.cdc.source.DBUtils;
 import org.apache.spark.api.java.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +62,7 @@ public class ResultSetToDMLRecord implements Function<ResultSet, StructuredRecor
       .set(Schemas.UPDATE_SCHEMA_FIELD, changeSchema.toString())
       .set(Schemas.UPDATE_VALUES_FIELD, getChangeData(row, changeSchema))
       .set(Schemas.CHANGE_TRACKING_VERSION, row.getString("CHANGE_TRACKING_VERSION"))
+      .set(Schemas.CDC_CURRENT_TIMESTAMP, row.getTimestamp("CDC_CURRENT_TIMESTAMP").getTime() * 1000)
       .build();
   }
 

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/SQLServerConnectionFactory.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/SQLServerConnectionFactory.java
@@ -28,12 +28,12 @@ import java.sql.DriverManager;
  * Note: This class does not do any connection management. Its the responsibility of the client
  * to manage/close the connection.
  */
-class SQLServerConnection implements JdbcRDD.ConnectionFactory {
+class SQLServerConnectionFactory implements JdbcRDD.ConnectionFactory {
   private final String connectionUrl;
   private final String userName;
   private final String password;
 
-  SQLServerConnection(String connectionUrl, String userName, String password) {
+  SQLServerConnectionFactory(String connectionUrl, String userName, String password) {
     this.connectionUrl = connectionUrl;
     this.userName = userName;
     this.password = password;

--- a/widgets/CTSQLServer-streamingsource.json
+++ b/widgets/CTSQLServer-streamingsource.json
@@ -4,28 +4,13 @@
   },
   "configuration-groups": [
     {
-      "label": "CT SQL Server Configuration",
+      "label": "Basic",
       "properties": [
         {
           "widget-type": "textbox",
           "label": "Reference Name",
           "name": "referenceName",
           "description": "Reference specifies the name to be used to track this external source"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Hostname",
-          "name": "hostname",
-          "description": "Hostname of the SQL Server from which the data needs to be offloaded. Ex: mysqlserver.net or 12.123.12.123"
-        },
-        {
-          "widget-type": "textbox",
-          "label": "Port",
-          "name": "port",
-          "description": "SQL Server Port",
-          "widget-attributes": {
-            "default": "1433"
-          }
         },
         {
           "widget-type": "textbox",
@@ -46,6 +31,52 @@
           "description": "SQL Server database name which needs to be tracked. Note: Change Tracking must be enabled on the database for the source to read the chage data"
         },
         {
+          "widget-type": "csv",
+          "label": "Table Whitelist",
+          "name": "tableWhitelist"
+        }
+      ]
+    },
+    {
+      "label": "Connection",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Hostname",
+          "name": "hostname",
+          "widget-attributes": {
+            "placeholder": "SQL Server hostname"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Port",
+          "name": "port",
+          "widget-attributes": {
+            "placeholder": "SQL Server Port. Ex: 1433"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Custom JDBC Connection",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "JDBC Plugin Name",
+          "name": "jdbcPluginName"
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Connection String",
+          "name": "connectionString"
+        }
+      ]
+    },
+    {
+      "label": "Advanced",
+      "properties": [
+        {
           "widget-type": "textbox",
           "label": "Max Retry Seconds",
           "name": "maxRetrySeconds"
@@ -65,11 +96,6 @@
           "widget-attributes": {
             "default": "0"
           }
-        },
-        {
-          "widget-type": "csv",
-          "label": "Table Whitelist",
-          "name": "tableWhitelist"
         }
       ]
     }


### PR DESCRIPTION
Add support for using a jdbc plugin instead of the sqlserver
driver that is packaged with the plugin. For example, somebody
could use the jtds driver if they want.

To support this, added config properties for the jdbc plugin
name and connection string. Copied relevant classes and methods
from db-plugins into DBUtils, DriverCleanup, and JDBCDriverShim
to support custom jdbc.

Also fixed a bug where the CDC timestamp was not being included
in the output records.