### PR TITLE
Changed timestamp zone to UTC. Force failure on CT version reset. Added statement list configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>io.cdap.plugin</groupId>
   <artifactId>cdc-plugins</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>2.0.6-SNAPSHOT</version>
   <name>cdc-plugins</name>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <groupId>io.cdap.plugin</groupId>
   <artifactId>cdc-plugins</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.5-SNAPSHOT</version>
   <name>cdc-plugins</name>
 
   <licenses>
@@ -91,7 +91,7 @@
     <netty.version>4.1.16.Final</netty.version>
     <junit.version>4.11</junit.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
-    <app.parents>system:cdap-data-streams[6.0.0,7.0.0)</app.parents>
+    <app.parents>system:cdap-data-streams[6.0.0-SNAPSHOT,7.0.0)</app.parents>
     <main.basedir>${project.basedir}</main.basedir>
 
     <skip.performance.test>true</skip.performance.test>

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServer.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServer.java
@@ -137,9 +137,8 @@ public class CTSQLServer extends StreamingSource<StructuredRecord> {
     LOG.info("Creating change information dstream");
     ClassTag<StructuredRecord> tag = ClassTag$.MODULE$.apply(StructuredRecord.class);
     CTInputDStream dstream = new CTInputDStream(context.getSparkStreamingContext().ssc(), connectionFactory,
-                                                conf.getOperationsList(), conf.getTableWhitelist(),
-                                                conf.getSequenceStartNum(), conf.getMaxRetrySeconds(),
-                                                conf.getMaxBatchSize());
+            conf.getOperationsList(), conf.getRetentionDays(), conf.getRetentionColumn(), conf.getTableWhitelist(),
+            conf.getSequenceStartNum(), conf.getMaxRetrySeconds(), conf.getMaxBatchSize());
     return JavaDStream.fromDStream(dstream, tag)
       .mapToPair(structuredRecord -> new Tuple2<>("", structuredRecord))
       // map the dstream with schema state store to detect changes in schema

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServer.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServer.java
@@ -137,8 +137,9 @@ public class CTSQLServer extends StreamingSource<StructuredRecord> {
     LOG.info("Creating change information dstream");
     ClassTag<StructuredRecord> tag = ClassTag$.MODULE$.apply(StructuredRecord.class);
     CTInputDStream dstream = new CTInputDStream(context.getSparkStreamingContext().ssc(), connectionFactory,
-                                                conf.getTableWhitelist(), conf.getSequenceStartNum(),
-                                                conf.getMaxRetrySeconds(), conf.getMaxBatchSize());
+                                                conf.getOperationsList(), conf.getTableWhitelist(),
+                                                conf.getSequenceStartNum(), conf.getMaxRetrySeconds(),
+                                                conf.getMaxBatchSize());
     return JavaDStream.fromDStream(dstream, tag)
       .mapToPair(structuredRecord -> new Tuple2<>("", structuredRecord))
       // map the dstream with schema state store to detect changes in schema

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServerConfig.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServerConfig.java
@@ -45,6 +45,8 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   public static final String JDBC_PLUGIN_NAME = "jdbcPluginName";
   public static final String CONNECTION_STRING = "connectionString";
   public static final String OPERATIONS_LIST = "operationsList";
+  public static final String RETENTION_DAYS = "retentionDays";
+  public static final String RETENTION_COLUMN = "retentionColumn";
 
   @Name(HOST_NAME)
   @Description("SQL Server hostname. This is not required if a connection string was specified.")
@@ -110,6 +112,17 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   @Nullable
   private final String operationsList;
 
+  @Name(RETENTION_DAYS)
+  @Description("Retention period for a table if DELETE operation is turned off. " +
+          "In this period all deletes will be imported. Set to 0 to ignore all deletes")
+  @Nullable
+  private final int retentionDays;
+
+  @Name(RETENTION_COLUMN)
+  @Description("Timestamp column to use for retention period (should be a part of Primary Key)")
+  @Nullable
+  private final String retentionColumn;
+
   public CTSQLServerConfig() {
     super("");
     this.hostname = null;
@@ -124,6 +137,8 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
     this.jdbcPluginName = null;
     this.connectionString = null;
     this.operationsList = null;
+    this.retentionDays = 0;
+    this.retentionColumn = null;
   }
 
   public String getHostname() {
@@ -182,6 +197,16 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
             Arrays.stream(operationsList.split(",")).map(String::trim).collect(Collectors.toSet());
   }
 
+
+  public int getRetentionDays() {
+    return retentionDays;
+  }
+
+  @Nullable
+  public String getRetentionColumn() {
+    return retentionColumn;
+  }
+
   @Override
   public void validate() {
     super.validate();
@@ -209,6 +234,10 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
 
     if (operationsList == null || operationsList.length() == 0) {
       throw new InvalidConfigPropertyException("Operations list couldn't be empty", OPERATIONS_LIST);
+    }
+
+    if (retentionDays > 0 && retentionColumn == null) {
+      throw new InvalidConfigPropertyException("Please set the retention timestamp column", RETENTION_COLUMN);
     }
 
   }

--- a/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServerConfig.java
+++ b/src/main/java/io/cdap/plugin/cdc/source/sqlserver/CTSQLServerConfig.java
@@ -44,6 +44,7 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   public static final String TABLE_WHITELIST = "tableWhitelist";
   public static final String JDBC_PLUGIN_NAME = "jdbcPluginName";
   public static final String CONNECTION_STRING = "connectionString";
+  public static final String OPERATIONS_LIST = "operationsList";
 
   @Name(HOST_NAME)
   @Description("SQL Server hostname. This is not required if a connection string was specified.")
@@ -104,6 +105,11 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
   @Nullable
   private final String connectionString;
 
+  @Name(OPERATIONS_LIST)
+  @Description("The list of operations to read (INSERT,UPDATE,DELETE)")
+  @Nullable
+  private final String operationsList;
+
   public CTSQLServerConfig() {
     super("");
     this.hostname = null;
@@ -117,6 +123,7 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
     this.tableWhitelist = null;
     this.jdbcPluginName = null;
     this.connectionString = null;
+    this.operationsList = null;
   }
 
   public String getHostname() {
@@ -170,6 +177,11 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
     return String.format("jdbc:sqlserver://%s:%s;DatabaseName=%s", hostname, port, dbName);
   }
 
+  public Set<String> getOperationsList() {
+    return operationsList == null ? Collections.emptySet() :
+            Arrays.stream(operationsList.split(",")).map(String::trim).collect(Collectors.toSet());
+  }
+
   @Override
   public void validate() {
     super.validate();
@@ -194,5 +206,10 @@ public class CTSQLServerConfig extends CDCReferencePluginConfig {
     if (port != null && (port < 0 || port > 65535)) {
       throw new InvalidConfigPropertyException("Port number should be in range 0-65535", PORT);
     }
+
+    if (operationsList == null || operationsList.length() == 0) {
+      throw new InvalidConfigPropertyException("Operations list couldn't be empty", OPERATIONS_LIST);
+    }
+
   }
 }

--- a/widgets/CTSQLServer-streamingsource.json
+++ b/widgets/CTSQLServer-streamingsource.json
@@ -77,6 +77,32 @@
       "label": "Advanced",
       "properties": [
         {
+          "name": "operationsList",
+          "label": "Statements list",
+          "widget-type": "multi-select",
+          "widget-attributes": {
+            "delimiter": ",",
+            "defaultValue": [
+              "I",
+              "U"
+            ],
+            "options": [
+              {
+                "id": "I",
+                "label": "INSERT"
+              },
+              {
+                "id": "U",
+                "label": "UPDATE"
+              },
+              {
+                "id": "D",
+                "label": "DELETE"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Max Retry Seconds",
           "name": "maxRetrySeconds"

--- a/widgets/CTSQLServer-streamingsource.json
+++ b/widgets/CTSQLServer-streamingsource.json
@@ -104,6 +104,19 @@
         },
         {
           "widget-type": "textbox",
+          "label": "Retention period (days)",
+          "name": "retentionDays",
+          "widget-attributes": {
+            "default": "0"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Retention timestamp column",
+          "name": "retentionColumn"
+        },
+        {
+          "widget-type": "textbox",
           "label": "Max Retry Seconds",
           "name": "maxRetrySeconds"
         },


### PR DESCRIPTION
- Changed timestamp zone to UTC
So CDC_CURRENT_TIMESTAMP field value won't be depend on source server location 
- Force failure on CT version reset
When ChangeTracking version got reset on source server it will force pipeline to failure
- Added statement list configuration
You can choose which statements to import. We don't need to take DELETEs because we want to store all historical information in destination. While source server has only 3months of data